### PR TITLE
Accurate barriers

### DIFF
--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -183,7 +183,7 @@ struct LatteDecompilerShader
 	std::bitset<LATTE_NUM_MAX_TEX_UNITS> textureUnitMask2;
 	uint16 textureUnitSamplerAssignment[LATTE_NUM_MAX_TEX_UNITS]{ 0 }; // LATTE_DECOMPILER_SAMPLER_NONE means undefined
 	bool textureUsesDepthCompare[LATTE_NUM_MAX_TEX_UNITS]{};
-	uint8 textureRenderTargetIndex[LATTE_NUM_MAX_TEX_UNITS] = {255};
+	uint8 textureRenderTargetIndex[LATTE_NUM_MAX_TEX_UNITS];
 
 	// analyzer stage (pixel outputs)
 	uint32 pixelColorOutputMask{ 0 }; // from LSB to MSB, 1 bit per written output. 1 if written (indices of color attachments)

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -183,6 +183,7 @@ struct LatteDecompilerShader
 	std::bitset<LATTE_NUM_MAX_TEX_UNITS> textureUnitMask2;
 	uint16 textureUnitSamplerAssignment[LATTE_NUM_MAX_TEX_UNITS]{ 0 }; // LATTE_DECOMPILER_SAMPLER_NONE means undefined
 	bool textureUsesDepthCompare[LATTE_NUM_MAX_TEX_UNITS]{};
+	uint8 textureRenderTargetIndex[LATTE_NUM_MAX_TEX_UNITS] = {255};
 
 	// analyzer stage (pixel outputs)
 	uint32 pixelColorOutputMask{ 0 }; // from LSB to MSB, 1 bit per written output. 1 if written (indices of color attachments)

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -855,6 +855,7 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
 	// check if textures are used as render targets
 	if (shader->shaderType == LatteConst::ShaderType::Pixel)
 	{
+	    uint8 colorBufferMask = LatteMRT::GetActiveColorBufferMask(shader, *shaderContext->contextRegistersNew);
 	    for (sint32 i = 0; i < shader->textureUnitListCount; i++)
         {
             sint32 textureIndex = shader->textureUnitList[i];
@@ -867,15 +868,11 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
 
             for (sint32 j = 0; j < LATTE_NUM_COLOR_TARGET; j++)
             {
+                if (((colorBufferMask) & (1 << j)) == 0)
+                    continue; // color buffer not enabled
+
                 uint32* colorBufferRegBase = shaderContext->contextRegisters + (mmCB_COLOR0_BASE + j);
                	uint32 regColorBufferBase = colorBufferRegBase[mmCB_COLOR0_BASE - mmCB_COLOR0_BASE] & 0xFFFFFF00; // the low 8 bits are ignored? How to Survive seems to rely on this
-               	uint32 regColorSize = colorBufferRegBase[mmCB_COLOR0_SIZE - mmCB_COLOR0_BASE];
-               	uint32 regColorInfo = colorBufferRegBase[mmCB_COLOR0_INFO - mmCB_COLOR0_BASE];
-               	uint32 regColorView = colorBufferRegBase[mmCB_COLOR0_VIEW - mmCB_COLOR0_BASE];
-               	// decode color buffer reg info
-               	Latte::E_HWTILEMODE colorBufferTileMode = (Latte::E_HWTILEMODE)((regColorInfo >> 8) & 0xF);
-               	uint32 numberType = (regColorInfo >> 12) & 7;
-               	Latte::E_GX2SURFFMT colorBufferFormat = LatteMRT::GetColorBufferFormat(j, *shaderContext->contextRegistersNew);
 
                	MPTR colorBufferPhysMem = regColorBufferBase;
 

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -866,6 +866,13 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
       		if (physAddr == MPTR_NULL)
                 continue; // invalid data
 
+            // Check for dimension
+            auto dim = shader->textureUnitDim[textureIndex];
+            // TODO: 2D arrays could technically be supported as well
+            if (dim != Latte::E_DIM::DIM_2D)
+                continue;
+
+            // Check if the texture is used as render target
             for (sint32 j = 0; j < LATTE_NUM_COLOR_TARGET; j++)
             {
                 if (((colorBufferMask) & (1 << j)) == 0)
@@ -876,6 +883,7 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
 
                	MPTR colorBufferPhysMem = regColorBufferBase;
 
+                // TODO: check if mip matches as well?
                 if (physAddr == colorBufferPhysMem)
                 {
                     shader->textureRenderTargetIndex[i] = j;

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -850,6 +850,42 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
 			shader->textureUnitList[shader->textureUnitListCount] = i;
 			shader->textureUnitListCount++;
 		}
+		shader->textureRenderTargetIndex[i] = 255;
+	}
+	// check if textures are used as render targets
+	if (shader->shaderType == LatteConst::ShaderType::Pixel)
+	{
+	    for (sint32 i = 0; i < shader->textureUnitListCount; i++)
+        {
+            sint32 textureIndex = shader->textureUnitList[i];
+      		const auto& texRegister = texRegs[textureIndex];
+
+      		// get physical address of texture data
+      		MPTR physAddr = (texRegister.word2.get_BASE_ADDRESS() << 8);
+      		if (physAddr == MPTR_NULL)
+                continue; // invalid data
+
+            for (sint32 j = 0; j < LATTE_NUM_COLOR_TARGET; j++)
+            {
+                uint32* colorBufferRegBase = shaderContext->contextRegisters + (mmCB_COLOR0_BASE + j);
+               	uint32 regColorBufferBase = colorBufferRegBase[mmCB_COLOR0_BASE - mmCB_COLOR0_BASE] & 0xFFFFFF00; // the low 8 bits are ignored? How to Survive seems to rely on this
+               	uint32 regColorSize = colorBufferRegBase[mmCB_COLOR0_SIZE - mmCB_COLOR0_BASE];
+               	uint32 regColorInfo = colorBufferRegBase[mmCB_COLOR0_INFO - mmCB_COLOR0_BASE];
+               	uint32 regColorView = colorBufferRegBase[mmCB_COLOR0_VIEW - mmCB_COLOR0_BASE];
+               	// decode color buffer reg info
+               	Latte::E_HWTILEMODE colorBufferTileMode = (Latte::E_HWTILEMODE)((regColorInfo >> 8) & 0xF);
+               	uint32 numberType = (regColorInfo >> 12) & 7;
+               	Latte::E_GX2SURFFMT colorBufferFormat = LatteMRT::GetColorBufferFormat(j, *shaderContext->contextRegistersNew);
+
+               	MPTR colorBufferPhysMem = regColorBufferBase;
+
+                if (physAddr == colorBufferPhysMem)
+                {
+                    shader->textureRenderTargetIndex[i] = j;
+                    break;
+                }
+            }
+        }
 	}
 	// for geometry shaders check the copy shader for stream writes
 	if (shader->shaderType == LatteConst::ShaderType::Geometry && shaderContext->parsedGSCopyShader->list_streamWrites.empty() == false)

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -872,6 +872,14 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
             if (dim != Latte::E_DIM::DIM_2D)
                 continue;
 
+            // Check for mip level
+            // TODO: uncomment?
+            /*
+            auto lastMip = texRegister.word5.get_LAST_LEVEL();
+            if (lastMip != 0)
+                continue;
+            */
+
             // Check if the texture is used as render target
             for (sint32 j = 0; j < LATTE_NUM_COLOR_TARGET; j++)
             {
@@ -886,7 +894,7 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
                 // TODO: check if mip matches as well?
                 if (physAddr == colorBufferPhysMem)
                 {
-                    shader->textureRenderTargetIndex[i] = j;
+                    shader->textureRenderTargetIndex[textureIndex] = j;
                     break;
                 }
             }

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -9,6 +9,9 @@
 #include "Cafe/HW/Latte/Core/LatteShader.h"
 #include "Cafe/HW/Latte/Renderer/Renderer.h"
 
+// Defined in LatteTextureLegacy.cpp
+Latte::E_GX2SURFFMT LatteTexture_ReconstructGX2Format(const Latte::LATTE_SQ_TEX_RESOURCE_WORD1_N& texUnitWord1, const Latte::LATTE_SQ_TEX_RESOURCE_WORD4_N& texUnitWord4);
+
 /*
  * Return index of used color attachment based on shader pixel export index (0-7)
  */
@@ -876,9 +879,12 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
             // TODO: uncomment?
             /*
             auto lastMip = texRegister.word5.get_LAST_LEVEL();
+            // TODO: multiple mip levels could technically be supported as well
             if (lastMip != 0)
                 continue;
             */
+
+            Latte::E_GX2SURFFMT format = LatteTexture_ReconstructGX2Format(texRegister.word1, texRegister.word4);
 
             // Check if the texture is used as render target
             for (sint32 j = 0; j < LATTE_NUM_COLOR_TARGET; j++)
@@ -890,9 +896,10 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
                	uint32 regColorBufferBase = colorBufferRegBase[mmCB_COLOR0_BASE - mmCB_COLOR0_BASE] & 0xFFFFFF00; // the low 8 bits are ignored? How to Survive seems to rely on this
 
                	MPTR colorBufferPhysMem = regColorBufferBase;
+                Latte::E_GX2SURFFMT colorBufferFormat = LatteMRT::GetColorBufferFormat(j, *shaderContext->contextRegistersNew);
 
                 // TODO: check if mip matches as well?
-                if (physAddr == colorBufferPhysMem)
+                if (physAddr == colorBufferPhysMem && format == colorBufferFormat)
                 {
                     shader->textureRenderTargetIndex[textureIndex] = j;
                     break;

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitMSL.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitMSL.cpp
@@ -2293,7 +2293,7 @@ static void _emitTEXSampleTextureCode(LatteDecompilerShaderContext* shaderContex
        	    if (isGather)
      			src->add("gather");
       		else
-                    src->add("sample");
+                src->add("sample");
        	    if (isCompare)
      			src->add("_compare");
       		src->addFmt("(samplr{}, ", texInstruction->textureFetch.textureIndex);
@@ -2456,25 +2456,25 @@ static void _emitTEXSampleTextureCode(LatteDecompilerShaderContext* shaderContex
     		// 1D textures don't support lod
     		if (texDim != Latte::E_DIM::DIM_1D && texDim != Latte::E_DIM::DIM_1D_ARRAY)
     		{
-      		if (texOpcode == GPU7_TEX_INST_SAMPLE_L || texOpcode == GPU7_TEX_INST_SAMPLE_LB || texOpcode == GPU7_TEX_INST_SAMPLE_C_L)
-      		{
-      		    src->add(", ");
-     			if (texOpcode == GPU7_TEX_INST_SAMPLE_LB)
-     			{
-        				src->addFmt("bias({})", _FormatFloatAsConstant((float)texInstruction->textureFetch.lodBias / 16.0f));
-     			}
-     			else
-     			{
-     			    // TODO: is this correct?
-        				src->add("level(");
+          		if (texOpcode == GPU7_TEX_INST_SAMPLE_L || texOpcode == GPU7_TEX_INST_SAMPLE_LB || texOpcode == GPU7_TEX_INST_SAMPLE_C_L)
+          		{
+          		    src->add(", ");
+         			if (texOpcode == GPU7_TEX_INST_SAMPLE_LB)
+         			{
+                        src->addFmt("bias({})", _FormatFloatAsConstant((float)texInstruction->textureFetch.lodBias / 16.0f));
+         			}
+         			else
+         			{
+         			    // TODO: is this correct?
+                        src->add("level(");
         				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 3, LATTE_DECOMPILER_DTYPE_FLOAT);
         				src->add(")");
-     			}
-      		}
-      		else if (texOpcode == GPU7_TEX_INST_SAMPLE_LZ || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ)
-      		{
-     			src->add(", level(0.0)");
-      		}
+         			}
+          		}
+          		else if (texOpcode == GPU7_TEX_INST_SAMPLE_LZ || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ)
+          		{
+         			src->add(", level(0.0)");
+          		}
     		}
     	}
     	// gradient parameters

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitMSL.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitMSL.cpp
@@ -2261,282 +2261,274 @@ static void _emitTEXSampleTextureCode(LatteDecompilerShaderContext* shaderContex
 	}
 
 	// Do a framebuffer fetch if possible
-	// TODO: support comparison samplers
-	if (static_cast<MetalRenderer*>(g_renderer.get())->SupportsFramebufferFetch())
+	uint8 renderTargetIndex = shaderContext->shader->textureRenderTargetIndex[texInstruction->textureFetch.textureIndex];
+	if (static_cast<MetalRenderer*>(g_renderer.get())->SupportsFramebufferFetch() && renderTargetIndex != 255)
 	{
-    	uint8 renderTargetIndex = shaderContext->shader->textureRenderTargetIndex[texInstruction->textureFetch.textureIndex];
-    	if (renderTargetIndex != 255)
-    	{
-    	    src->addFmt("col{}.", renderTargetIndex);
-    		// TODO: clean up
-    		std::string components[] = {"x", "y", "z", "w"};
-    		for (sint32 i = 0; i < numWrittenElements; i++)
-            {
-                src->addFmt("{}", components[i]);
-            }
-    		src->add(");" _CRLF);
-    		return;
-    	}
-	}
-
-	if (emulateCompare)
-	{
-        cemu_assert_debug(!isGather);
-
-		src->add("sampleCompareEmulate(");
-	}
-
-	src->addFmt("tex{}", texInstruction->textureFetch.textureIndex);
-	if (!emulateCompare)
-	{
-	    src->add(".");
-    	if (isRead)
-    	{
-    		if (hasOffset)
-    			cemu_assert_unimplemented();
-    		src->add("read(");
-    		unnormalizationHandled = true;
-    		useTexelCoordinates = true;
-    	}
-    	else
-    	{
-    	    if (isGather)
-    			src->add("gather");
-    		else
-                src->add("sample");
-    	    if (isCompare)
-    			src->add("_compare");
-    		src->addFmt("(samplr{}, ", texInstruction->textureFetch.textureIndex);
-    	}
+	    // TODO: support comparison samplers
+   	    src->addFmt("col{}", renderTargetIndex);
 	}
 	else
 	{
-	    src->addFmt(", samplr{}, ", texInstruction->textureFetch.textureIndex);
-	}
+    	if (emulateCompare)
+    	{
+            cemu_assert_debug(!isGather);
 
-	// for textureGather() add shift (todo: depends on rounding mode set in sampler registers?)
-	if (texOpcode == GPU7_TEX_INST_FETCH4)
-	{
-		if (texDim == Latte::E_DIM::DIM_2D)
-		{
-			//src->addFmt2("(vec2(-0.1) / vec2(textureSize(tex{},0).xy)) + ", texInstruction->textureIndex);
+    		src->add("sampleCompareEmulate(");
+    	}
 
-			// vec2(-0.00001) is minimum to break Nvidia
-			// vec2(0.0001) is minimum to fix shadows on Intel, also fixes it on AMD (Windows and Linux)
+    	src->addFmt("tex{}", texInstruction->textureFetch.textureIndex);
+    	if (!emulateCompare)
+    	{
+    	    src->add(".");
+       	if (isRead)
+       	{
+      		if (hasOffset)
+     			cemu_assert_unimplemented();
+      		src->add("read(");
+      		unnormalizationHandled = true;
+      		useTexelCoordinates = true;
+       	}
+       	else
+       	{
+       	    if (isGather)
+     			src->add("gather");
+      		else
+                    src->add("sample");
+       	    if (isCompare)
+     			src->add("_compare");
+      		src->addFmt("(samplr{}, ", texInstruction->textureFetch.textureIndex);
+       	}
+    	}
+    	else
+    	{
+    	    src->addFmt(", samplr{}, ", texInstruction->textureFetch.textureIndex);
+    	}
 
-			// todo - emulating coordinate rounding mode correctly is tricky
-			// GX2 supports two modes: Truncate or rounding according to DX9 rules
-			// Vulkan uses truncate mode when point sampling (min and mag is both nearest) otherwise it uses rounding
-
-			// adding a small fixed bias is enough to avoid vendor-specific cases where small inaccuracies cause the number to get rounded down due to truncation
-			src->addFmt("float2(0.0001) + ");
-		}
-	}
-
-	const sint32 texCoordDataType = (texOpcode == GPU7_TEX_INST_LD) ? LATTE_DECOMPILER_DTYPE_SIGNED_INT : LATTE_DECOMPILER_DTYPE_FLOAT;
-	if(useTexelCoordinates)
-	{
-		// handle integer coordinates for texelFetch
-		if (texDim == Latte::E_DIM::DIM_2D || texDim == Latte::E_DIM::DIM_2D_MSAA)
-		{
-			src->add("uint2(");
-			src->add("float2(");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, texCoordDataType);
-			src->addFmt(", ");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, texCoordDataType);
-
-			src->addFmt(")*supportBuffer.tex{}Scale", texInstruction->textureFetch.textureIndex); // close float2 and scale
-
-			src->add("), 0"); // close int2 and lod param
-			// todo - lod
-		}
-		else if (texDim == Latte::E_DIM::DIM_1D)
-		{
-			// VC DS games forget to initialize textures and use texel fetch on an uninitialized texture (a dim of 0 maps to 1D)
-			src->add("uint(");
-			src->add("float(");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, (texOpcode == GPU7_TEX_INST_LD) ? LATTE_DECOMPILER_DTYPE_SIGNED_INT : LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->addFmt(")*supportBuffer.tex{}Scale.x", texInstruction->textureFetch.textureIndex);
-			src->add("), 0");
-			// todo - lod
-		}
-		else
-			cemu_assert_debug(false);
-	}
-	else /* useTexelCoordinates == false */
-	{
-		// float coordinates
-		if ( (texOpcode == GPU7_TEX_INST_SAMPLE_C || texOpcode == GPU7_TEX_INST_SAMPLE_C_L || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ) )
-		{
-			// shadow sampler
-			if (texDim == Latte::E_DIM::DIM_2D_ARRAY)
-			{
-				// 3 coords + compare value
-				src->add("float2(");
-				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
-				src->add(", ");
-				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
-				src->add("), uint(rint(");
-				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_FLOAT);
-				src->add("))");
-
-				src->addFmt(", {}", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[3], -1, -1, -1, tempBuffer0));
-			}
-			else if (texDim == Latte::E_DIM::DIM_CUBEMAP)
-			{
-				// 2 coords + faceId
-				if (texInstruction->textureFetch.srcSel[0] >= 4 || texInstruction->textureFetch.srcSel[1] >= 4)
-				{
-					debugBreakpoint();
-				}
-				src->addFmt("redcCUBEReverse({},", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], texInstruction->textureFetch.srcSel[1], -1, -1, tempBuffer0));
-				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_SIGNED_INT);
-				src->addFmt(")");
-				src->addFmt(", uint(cubeMapArrayIndex{})", texInstruction->textureFetch.textureIndex); // cubemap index
-			}
-			else if (texDim == Latte::E_DIM::DIM_1D)
-			{
-				// 1 coord + 1 unused coord (per  spec) + compare value
-				if (texInstruction->textureFetch.srcSel[0] >= 4)
-				{
-					debugBreakpoint();
-				}
-				src->addFmt("{}, {}", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], -1, -1, -1, tempBuffer0), _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[3], -1, -1, -1, tempBuffer1));
-			}
-			else
-			{
-				// 2 coords + compare value (as float3)
-				if (texInstruction->textureFetch.srcSel[0] >= 4 && texInstruction->textureFetch.srcSel[1] >= 4)
-				{
-					debugBreakpoint();
-				}
-				src->addFmt("float2({}), {}", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], texInstruction->textureFetch.srcSel[1], -1, -1, tempBuffer0), _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[3], -1, -1, -1, tempBuffer1));
-			}
-		}
-		else if(texDim == Latte::E_DIM::DIM_2D_ARRAY)
-		{
-			// 3 coords
-			src->add("float2(");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add(", ");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add("), uint(rint(");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add("))");
-		}
-		else if(texDim == Latte::E_DIM::DIM_3D)
-		{
-			// 3 coords
-			src->add("float3(");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add(", ");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add(", ");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add(")");
-		}
-		else if( texDim == Latte::E_DIM::DIM_CUBEMAP )
-		{
-			// 2 coords + faceId
-			cemu_assert_debug(texInstruction->textureFetch.srcSel[0] < 4);
-			cemu_assert_debug(texInstruction->textureFetch.srcSel[1] < 4);
-			src->addFmt("redcCUBEReverse({},", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], texInstruction->textureFetch.srcSel[1], -1, -1, tempBuffer0));
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_SIGNED_INT);
-			src->add(")");
-			src->addFmt(", uint(cubeMapArrayIndex{})", texInstruction->textureFetch.textureIndex); // cubemap index
-		}
-		else if( texDim == Latte::E_DIM::DIM_1D )
-		{
-			// 1 coord
-			src->add(_getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], -1, -1, -1, tempBuffer0));
-		}
-		else
-		{
-			// 2 coords
-			src->add("float2(");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add(",");
-			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
-			src->add(")");
-			// avoid truncate to effectively round downwards on texel edges
-			if (ActiveSettings::ForceSamplerRoundToPrecision())
-				src->addFmt("+ float2(1.0)/float2(tex{}.get_width(), tex{}.get_height())/512.0", texInstruction->textureFetch.textureIndex, texInstruction->textureFetch.textureIndex);
-		}
-		// lod or lod bias parameter
-		// 1D textures don't support lod
-		if (texDim != Latte::E_DIM::DIM_1D && texDim != Latte::E_DIM::DIM_1D_ARRAY)
-		{
-    		if (texOpcode == GPU7_TEX_INST_SAMPLE_L || texOpcode == GPU7_TEX_INST_SAMPLE_LB || texOpcode == GPU7_TEX_INST_SAMPLE_C_L)
+    	// for textureGather() add shift (todo: depends on rounding mode set in sampler registers?)
+    	if (texOpcode == GPU7_TEX_INST_FETCH4)
+    	{
+    		if (texDim == Latte::E_DIM::DIM_2D)
     		{
-    		    src->add(", ");
-    			if (texOpcode == GPU7_TEX_INST_SAMPLE_LB)
+    			//src->addFmt2("(vec2(-0.1) / vec2(textureSize(tex{},0).xy)) + ", texInstruction->textureIndex);
+
+    			// vec2(-0.00001) is minimum to break Nvidia
+    			// vec2(0.0001) is minimum to fix shadows on Intel, also fixes it on AMD (Windows and Linux)
+
+    			// todo - emulating coordinate rounding mode correctly is tricky
+    			// GX2 supports two modes: Truncate or rounding according to DX9 rules
+    			// Vulkan uses truncate mode when point sampling (min and mag is both nearest) otherwise it uses rounding
+
+    			// adding a small fixed bias is enough to avoid vendor-specific cases where small inaccuracies cause the number to get rounded down due to truncation
+    			src->addFmt("float2(0.0001) + ");
+    		}
+    	}
+
+    	const sint32 texCoordDataType = (texOpcode == GPU7_TEX_INST_LD) ? LATTE_DECOMPILER_DTYPE_SIGNED_INT : LATTE_DECOMPILER_DTYPE_FLOAT;
+    	if(useTexelCoordinates)
+    	{
+    		// handle integer coordinates for texelFetch
+    		if (texDim == Latte::E_DIM::DIM_2D || texDim == Latte::E_DIM::DIM_2D_MSAA)
+    		{
+    			src->add("uint2(");
+    			src->add("float2(");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, texCoordDataType);
+    			src->addFmt(", ");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, texCoordDataType);
+
+    			src->addFmt(")*supportBuffer.tex{}Scale", texInstruction->textureFetch.textureIndex); // close float2 and scale
+
+    			src->add("), 0"); // close int2 and lod param
+    			// todo - lod
+    		}
+    		else if (texDim == Latte::E_DIM::DIM_1D)
+    		{
+    			// VC DS games forget to initialize textures and use texel fetch on an uninitialized texture (a dim of 0 maps to 1D)
+    			src->add("uint(");
+    			src->add("float(");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, (texOpcode == GPU7_TEX_INST_LD) ? LATTE_DECOMPILER_DTYPE_SIGNED_INT : LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->addFmt(")*supportBuffer.tex{}Scale.x", texInstruction->textureFetch.textureIndex);
+    			src->add("), 0");
+    			// todo - lod
+    		}
+    		else
+    			cemu_assert_debug(false);
+    	}
+    	else /* useTexelCoordinates == false */
+    	{
+    		// float coordinates
+    		if ( (texOpcode == GPU7_TEX_INST_SAMPLE_C || texOpcode == GPU7_TEX_INST_SAMPLE_C_L || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ) )
+    		{
+    			// shadow sampler
+    			if (texDim == Latte::E_DIM::DIM_2D_ARRAY)
     			{
-    				src->addFmt("bias({})", _FormatFloatAsConstant((float)texInstruction->textureFetch.lodBias / 16.0f));
+    				// 3 coords + compare value
+    				src->add("float2(");
+    				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
+    				src->add(", ");
+    				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
+    				src->add("), uint(rint(");
+    				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_FLOAT);
+    				src->add("))");
+
+    				src->addFmt(", {}", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[3], -1, -1, -1, tempBuffer0));
+    			}
+    			else if (texDim == Latte::E_DIM::DIM_CUBEMAP)
+    			{
+    				// 2 coords + faceId
+    				if (texInstruction->textureFetch.srcSel[0] >= 4 || texInstruction->textureFetch.srcSel[1] >= 4)
+    				{
+    					debugBreakpoint();
+    				}
+    				src->addFmt("redcCUBEReverse({},", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], texInstruction->textureFetch.srcSel[1], -1, -1, tempBuffer0));
+    				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_SIGNED_INT);
+    				src->addFmt(")");
+    				src->addFmt(", uint(cubeMapArrayIndex{})", texInstruction->textureFetch.textureIndex); // cubemap index
+    			}
+    			else if (texDim == Latte::E_DIM::DIM_1D)
+    			{
+    				// 1 coord + 1 unused coord (per  spec) + compare value
+    				if (texInstruction->textureFetch.srcSel[0] >= 4)
+    				{
+    					debugBreakpoint();
+    				}
+    				src->addFmt("{}, {}", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], -1, -1, -1, tempBuffer0), _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[3], -1, -1, -1, tempBuffer1));
     			}
     			else
     			{
-    			    // TODO: is this correct?
-    				src->add("level(");
-    				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 3, LATTE_DECOMPILER_DTYPE_FLOAT);
-    				src->add(")");
+    				// 2 coords + compare value (as float3)
+    				if (texInstruction->textureFetch.srcSel[0] >= 4 && texInstruction->textureFetch.srcSel[1] >= 4)
+    				{
+    					debugBreakpoint();
+    				}
+    				src->addFmt("float2({}), {}", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], texInstruction->textureFetch.srcSel[1], -1, -1, tempBuffer0), _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[3], -1, -1, -1, tempBuffer1));
     			}
     		}
-    		else if (texOpcode == GPU7_TEX_INST_SAMPLE_LZ || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ)
+    		else if(texDim == Latte::E_DIM::DIM_2D_ARRAY)
     		{
-    			src->add(", level(0.0)");
+    			// 3 coords
+    			src->add("float2(");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add(", ");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add("), uint(rint(");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add("))");
     		}
-		}
-	}
-	// gradient parameters
-	if (texOpcode == GPU7_TEX_INST_SAMPLE_G)
-	{
-		if (texDim == Latte::E_DIM::DIM_2D ||
-			texDim == Latte::E_DIM::DIM_1D)
-		{
-			src->add(", gradient2d(gradH.xy, gradV.xy)");
-		}
-		else
-		{
-			cemu_assert_unimplemented();
-		}
-	}
+    		else if(texDim == Latte::E_DIM::DIM_3D)
+    		{
+    			// 3 coords
+    			src->add("float3(");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add(", ");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add(", ");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add(")");
+    		}
+    		else if( texDim == Latte::E_DIM::DIM_CUBEMAP )
+    		{
+    			// 2 coords + faceId
+    			cemu_assert_debug(texInstruction->textureFetch.srcSel[0] < 4);
+    			cemu_assert_debug(texInstruction->textureFetch.srcSel[1] < 4);
+    			src->addFmt("redcCUBEReverse({},", _getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], texInstruction->textureFetch.srcSel[1], -1, -1, tempBuffer0));
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 2, LATTE_DECOMPILER_DTYPE_SIGNED_INT);
+    			src->add(")");
+    			src->addFmt(", uint(cubeMapArrayIndex{})", texInstruction->textureFetch.textureIndex); // cubemap index
+    		}
+    		else if( texDim == Latte::E_DIM::DIM_1D )
+    		{
+    			// 1 coord
+    			src->add(_getTexGPRAccess(shaderContext, texInstruction->srcGpr, LATTE_DECOMPILER_DTYPE_FLOAT, texInstruction->textureFetch.srcSel[0], -1, -1, -1, tempBuffer0));
+    		}
+    		else
+    		{
+    			// 2 coords
+    			src->add("float2(");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 0, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add(",");
+    			_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 1, LATTE_DECOMPILER_DTYPE_FLOAT);
+    			src->add(")");
+    			// avoid truncate to effectively round downwards on texel edges
+    			if (ActiveSettings::ForceSamplerRoundToPrecision())
+    				src->addFmt("+ float2(1.0)/float2(tex{}.get_width(), tex{}.get_height())/512.0", texInstruction->textureFetch.textureIndex, texInstruction->textureFetch.textureIndex);
+    		}
+    		// lod or lod bias parameter
+    		// 1D textures don't support lod
+    		if (texDim != Latte::E_DIM::DIM_1D && texDim != Latte::E_DIM::DIM_1D_ARRAY)
+    		{
+      		if (texOpcode == GPU7_TEX_INST_SAMPLE_L || texOpcode == GPU7_TEX_INST_SAMPLE_LB || texOpcode == GPU7_TEX_INST_SAMPLE_C_L)
+      		{
+      		    src->add(", ");
+     			if (texOpcode == GPU7_TEX_INST_SAMPLE_LB)
+     			{
+        				src->addFmt("bias({})", _FormatFloatAsConstant((float)texInstruction->textureFetch.lodBias / 16.0f));
+     			}
+     			else
+     			{
+     			    // TODO: is this correct?
+        				src->add("level(");
+        				_emitTEXSampleCoordInputComponent(shaderContext, texInstruction, 3, LATTE_DECOMPILER_DTYPE_FLOAT);
+        				src->add(")");
+     			}
+      		}
+      		else if (texOpcode == GPU7_TEX_INST_SAMPLE_LZ || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ)
+      		{
+     			src->add(", level(0.0)");
+      		}
+    		}
+    	}
+    	// gradient parameters
+    	if (texOpcode == GPU7_TEX_INST_SAMPLE_G)
+    	{
+    		if (texDim == Latte::E_DIM::DIM_2D ||
+    			texDim == Latte::E_DIM::DIM_1D)
+    		{
+    			src->add(", gradient2d(gradH.xy, gradV.xy)");
+    		}
+    		else
+    		{
+    			cemu_assert_unimplemented();
+    		}
+    	}
 
-	// offset
-	if( texOpcode == GPU7_TEX_INST_SAMPLE_L || texOpcode == GPU7_TEX_INST_SAMPLE_LZ || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ || texOpcode == GPU7_TEX_INST_SAMPLE || texOpcode == GPU7_TEX_INST_SAMPLE_C )
-	{
-		if( hasOffset )
-		{
-			uint8 offsetComponentCount = 0;
-			if( texDim == Latte::E_DIM::DIM_1D )
-				offsetComponentCount = 1;
-			else if( texDim == Latte::E_DIM::DIM_2D )
-				offsetComponentCount = 2;
-			else if( texDim == Latte::E_DIM::DIM_3D )
-				offsetComponentCount = 3;
-			else if( texDim == Latte::E_DIM::DIM_2D_ARRAY )
-				offsetComponentCount = 2;
-			else
-				cemu_assert_unimplemented();
+    	// offset
+    	if( texOpcode == GPU7_TEX_INST_SAMPLE_L || texOpcode == GPU7_TEX_INST_SAMPLE_LZ || texOpcode == GPU7_TEX_INST_SAMPLE_C_LZ || texOpcode == GPU7_TEX_INST_SAMPLE || texOpcode == GPU7_TEX_INST_SAMPLE_C )
+    	{
+    		if( hasOffset )
+    		{
+    			uint8 offsetComponentCount = 0;
+    			if( texDim == Latte::E_DIM::DIM_1D )
+    				offsetComponentCount = 1;
+    			else if( texDim == Latte::E_DIM::DIM_2D )
+    				offsetComponentCount = 2;
+    			else if( texDim == Latte::E_DIM::DIM_3D )
+    				offsetComponentCount = 3;
+    			else if( texDim == Latte::E_DIM::DIM_2D_ARRAY )
+    				offsetComponentCount = 2;
+    			else
+    				cemu_assert_unimplemented();
 
-			if( (texInstruction->textureFetch.offsetX&1) )
-				cemu_assert_unimplemented();
-			if( (texInstruction->textureFetch.offsetY&1) )
-				cemu_assert_unimplemented();
-			if ((texInstruction->textureFetch.offsetZ & 1))
-				cemu_assert_unimplemented();
+    			if( (texInstruction->textureFetch.offsetX&1) )
+    				cemu_assert_unimplemented();
+    			if( (texInstruction->textureFetch.offsetY&1) )
+    				cemu_assert_unimplemented();
+    			if ((texInstruction->textureFetch.offsetZ & 1))
+    				cemu_assert_unimplemented();
 
-			if( offsetComponentCount == 1 )
-				src->addFmt(",{}", texInstruction->textureFetch.offsetX/2);
-			else if( offsetComponentCount == 2 )
-				src->addFmt(",int2({},{})", texInstruction->textureFetch.offsetX/2, texInstruction->textureFetch.offsetY/2, texInstruction->textureFetch.offsetZ/2);
-			else if( offsetComponentCount == 3 )
-				src->addFmt(",int3({},{},{})", texInstruction->textureFetch.offsetX/2, texInstruction->textureFetch.offsetY/2, texInstruction->textureFetch.offsetZ/2);
-		}
-	}
+    			if( offsetComponentCount == 1 )
+    				src->addFmt(",{}", texInstruction->textureFetch.offsetX/2);
+    			else if( offsetComponentCount == 2 )
+    				src->addFmt(",int2({},{})", texInstruction->textureFetch.offsetX/2, texInstruction->textureFetch.offsetY/2, texInstruction->textureFetch.offsetZ/2);
+    			else if( offsetComponentCount == 3 )
+    				src->addFmt(",int3({},{},{})", texInstruction->textureFetch.offsetX/2, texInstruction->textureFetch.offsetY/2, texInstruction->textureFetch.offsetZ/2);
+    		}
+    	}
 
-	// lod bias (TODO: wht?)
+    	// lod bias (TODO: wht?)
 
-    src->add(")");
+        src->add(")");
+    }
+
 	// sample_compare doesn't return a float
     if (!isCompare)
     {

--- a/src/Cafe/HW/Latte/Renderer/Metal/LatteToMtl.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/LatteToMtl.h
@@ -55,7 +55,7 @@ inline const char* GetDataTypeStr(MetalDataType dataType)
 	    return "float4";
 	default:
 	    cemu_assert_suspicious();
-		return "";
+		return "INVALID";
 	}
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
@@ -1926,6 +1926,11 @@ void MetalRenderer::BindStageResources(MTL::RenderCommandEncoder* renderCommandE
 	{
 		const auto relative_textureUnit = shader->resourceMapping.getTextureUnitFromBindingPoint(i);
 		auto hostTextureUnit = relative_textureUnit;
+
+		// Don't bind textures that are accessed with a framebuffer fetch
+		if (shader->textureRenderTargetIndex[relative_textureUnit] != 255)
+            continue;
+
 		auto textureDim = shader->textureUnitDim[relative_textureUnit];
 		auto texUnitRegIndex = hostTextureUnit * 7;
 		switch (shader->shaderType)

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
@@ -87,7 +87,7 @@ MetalRenderer::MetalRenderer()
 
     // Feature support
     m_isAppleGPU = m_device->supportsFamily(MTL::GPUFamilyApple1);
-    m_supportsFramebufferFetch = m_device->supportsFamily(MTL::GPUFamilyApple2);
+    m_supportsFramebufferFetch = GetConfig().framebuffer_fetch.GetValue() ? m_device->supportsFamily(MTL::GPUFamilyApple2) : false;
     m_hasUnifiedMemory = m_device->hasUnifiedMemory();
     m_supportsMetal3 = m_device->supportsFamily(MTL::GPUFamilyMetal3);
     m_recommendedMaxVRAMUsage = m_device->recommendedMaxWorkingSetSize();

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
@@ -1008,6 +1008,7 @@ void MetalRenderer::draw_execute(uint32 baseVertex, uint32 baseInstance, uint32 
     LatteDecompilerShader* pixelShader = LatteSHRC_GetActivePixelShader();
     const auto fetchShader = LatteSHRC_GetActiveFetchShader();
 
+    /*
     bool neverSkipAccurateBarrier = false;
 
     // "Accurate barriers" is usually enabled globally but since the CPU cost is substantial we allow users to disable it (debug -> 'Accurate barriers' option)
@@ -1037,6 +1038,7 @@ void MetalRenderer::draw_execute(uint32 baseVertex, uint32 baseInstance, uint32 
             cemuLog_logOnce(LogType::Force, "Ending render pass due to render target self-dependency\n");
         }
 	}
+	*/
 
     // Primitive type
     const LattePrimitiveMode primitiveMode = static_cast<LattePrimitiveMode>(LatteGPUState.contextRegister[mmVGT_PRIMITIVE_TYPE]);
@@ -1867,6 +1869,7 @@ bool MetalRenderer::AcquireDrawable(bool mainWindow)
     return layer.AcquireDrawable();
 }
 
+/*
 bool MetalRenderer::CheckIfRenderPassNeedsFlush(LatteDecompilerShader* shader)
 {
     sint32 textureCount = shader->resourceMapping.getTextureCount();
@@ -1916,6 +1919,7 @@ bool MetalRenderer::CheckIfRenderPassNeedsFlush(LatteDecompilerShader* shader)
 
 	return false;
 }
+*/
 
 void MetalRenderer::BindStageResources(MTL::RenderCommandEncoder* renderCommandEncoder, LatteDecompilerShader* shader, bool usesGeometryShader)
 {

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
@@ -362,7 +362,7 @@ public:
 
     bool AcquireDrawable(bool mainWindow);
 
-    bool CheckIfRenderPassNeedsFlush(LatteDecompilerShader* shader);
+    //bool CheckIfRenderPassNeedsFlush(LatteDecompilerShader* shader);
     void BindStageResources(MTL::RenderCommandEncoder* renderCommandEncoder, LatteDecompilerShader* shader, bool usesGeometryShader);
 
     void ClearColorTextureInternal(MTL::Texture* mtlTexture, sint32 sliceIndex, sint32 mipIndex, float r, float g, float b, float a);

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
@@ -125,8 +125,7 @@ struct MetalState
     MetalActiveFBOState m_lastUsedFBO;
 
     size_t m_vertexBufferOffsets[MAX_MTL_VERTEX_BUFFERS];
-    // TODO: find out what is the max number of bound textures on the Wii U
-    class LatteTextureViewMtl* m_textures[64] = {nullptr};
+    class LatteTextureViewMtl* m_textures[LATTE_NUM_MAX_TEX_UNITS] = {nullptr};
     size_t m_uniformBufferOffsets[METAL_GENERAL_SHADER_TYPE_TOTAL][MAX_MTL_BUFFERS];
 
     MTL::Viewport m_viewport;

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
@@ -375,6 +375,11 @@ public:
         return m_isAppleGPU;
     }
 
+    bool SupportsFramebufferFetch() const
+    {
+        return m_supportsFramebufferFetch;
+    }
+
     bool HasUnifiedMemory() const
     {
         return m_hasUnifiedMemory;
@@ -477,6 +482,7 @@ private:
 
 	// Feature support
 	bool m_isAppleGPU;
+	bool m_supportsFramebufferFetch;
 	bool m_hasUnifiedMemory;
 	bool m_supportsMetal3;
 	uint32 m_recommendedMaxVRAMUsage;

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -338,6 +338,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 #endif
 	gdb_port = debug.get("GDBPort", 1337);
 	gpu_capture_dir = debug.get("GPUCaptureDir", "");
+	framebuffer_fetch = debug.get("FramebufferFetch", true);
 
 	// input
 	auto input = parser.get("Input");
@@ -540,7 +541,8 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	debug.set("CrashDumpUnix", crash_dump.GetValue());
 #endif
 	debug.set("GDBPort", gdb_port);
-	debug.set("GPUCaptureDir", gpu_capture_dir.GetValue());
+	debug.set("GPUCaptureDir", gpu_capture_dir);
+	debug.set("FramebufferFetch", framebuffer_fetch);
 
 	// input
 	auto input = config.set("Input");

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -527,7 +527,8 @@ struct CemuConfig
 	// debug
 	ConfigValueBounds<CrashDump> crash_dump{ CrashDump::Disabled };
 	ConfigValue<uint16> gdb_port{ 1337 };
-	ConfigValue<std::string> gpu_capture_dir{};
+	ConfigValue<std::string> gpu_capture_dir{ "" };
+	ConfigValue<bool> framebuffer_fetch{ true };
 
 	void Load(XMLConfigParser& parser);
 	void Save(XMLConfigParser& parser);

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -910,6 +910,18 @@ wxPanel* GeneralSettings2::AddDebugPage(wxNotebook* notebook)
 		debug_panel_sizer->Add(debug_row, 0, wxALL | wxEXPAND, 5);
 	}
 
+	{
+		auto* debug_row = new wxFlexGridSizer(0, 2, 0, 0);
+		debug_row->SetFlexibleDirection(wxBOTH);
+		debug_row->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+		m_framebuffer_fetch = new wxCheckBox(panel, wxID_ANY, _("Framebuffer fetch"));
+		m_framebuffer_fetch->SetToolTip(_("Enable framebuffer fetch for eligible textures on supported devices."));
+
+		debug_row->Add(m_framebuffer_fetch, 0, wxALL | wxEXPAND, 5);
+		debug_panel_sizer->Add(debug_row, 0, wxALL | wxEXPAND, 5);
+	}
+
 	panel->SetSizerAndFit(debug_panel_sizer);
 
 	return panel;
@@ -1121,6 +1133,7 @@ void GeneralSettings2::StoreConfig()
 	config.crash_dump = (CrashDump)m_crash_dump->GetSelection();
 	config.gdb_port = m_gdb_port->GetValue();
 	config.gpu_capture_dir = m_gpu_capture_dir->GetValue().utf8_string();
+	config.framebuffer_fetch = m_framebuffer_fetch->IsChecked();
 
 	g_config.Save();
 }
@@ -1816,6 +1829,7 @@ void GeneralSettings2::ApplyConfig()
 	m_crash_dump->SetSelection((int)config.crash_dump.GetValue());
 	m_gdb_port->SetValue(config.gdb_port.GetValue());
 	m_gpu_capture_dir->SetValue(wxHelper::FromUtf8(config.gpu_capture_dir.GetValue()));
+	m_framebuffer_fetch->SetValue(config.framebuffer_fetch);
 }
 
 void GeneralSettings2::OnAudioAPISelected(wxCommandEvent& event)

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -80,6 +80,7 @@ private:
 	wxChoice* m_crash_dump;
 	wxSpinCtrl* m_gdb_port;
 	wxTextCtrl* m_gpu_capture_dir;
+	wxCheckBox* m_framebuffer_fetch;
 
 	void OnAccountCreate(wxCommandEvent& event);
 	void OnAccountDelete(wxCommandEvent& event);


### PR DESCRIPTION
Implements accurate barriers through framebuffer fetch instead of ending the render pass. Should improve performance in botw significantly.
TODO:
- [x] make sure the check for self-dependency doesn't have false positives
- [x] check for framebuffer fetch support
- [ ] support getting render target size in pixel shaders