### PR TITLE
AIR cache

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -524,6 +524,7 @@ void LatteSHRC_UpdateVSBaseHash(uint8* vertexShaderPtr, uint32 vertexShaderSize,
 	if (LatteGPUState.contextNew.PA_CL_CLIP_CNTL.get_DX_CLIP_SPACE_DEF())
 		vsHash += 0x1537;
 
+#if ENABLE_METAL
 	if (g_renderer->GetType() == RendererAPI::Metal)
 	{
 	    if (usesGeometryShader || _activeFetchShader->mtlFetchVertexManually)
@@ -542,27 +543,28 @@ void LatteSHRC_UpdateVSBaseHash(uint8* vertexShaderPtr, uint32 vertexShaderSize,
 
 	    if (!usesGeometryShader)
 		{
-  		// Rasterization
-  		bool rasterizationEnabled = !LatteGPUState.contextNew.PA_CL_CLIP_CNTL.get_DX_RASTERIZATION_KILL();
+      		// Rasterization
+      		bool rasterizationEnabled = !LatteGPUState.contextNew.PA_CL_CLIP_CNTL.get_DX_RASTERIZATION_KILL();
 
-  		// HACK
-  		if (!LatteGPUState.contextNew.PA_CL_VTE_CNTL.get_VPORT_X_OFFSET_ENA())
- 			rasterizationEnabled = true;
+      		// HACK
+      		if (!LatteGPUState.contextNew.PA_CL_VTE_CNTL.get_VPORT_X_OFFSET_ENA())
+     			rasterizationEnabled = true;
 
-  		const auto& polygonControlReg = LatteGPUState.contextNew.PA_SU_SC_MODE_CNTL;
-  		uint32 cullFront = polygonControlReg.get_CULL_FRONT();
-  		uint32 cullBack = polygonControlReg.get_CULL_BACK();
-  		if (cullFront && cullBack)
-  		    rasterizationEnabled = false;
+      		const auto& polygonControlReg = LatteGPUState.contextNew.PA_SU_SC_MODE_CNTL;
+      		uint32 cullFront = polygonControlReg.get_CULL_FRONT();
+      		uint32 cullBack = polygonControlReg.get_CULL_BACK();
+      		if (cullFront && cullBack)
+      		    rasterizationEnabled = false;
 
-  		if (rasterizationEnabled)
-  		    vsHash += 51ULL;
+      		if (rasterizationEnabled)
+      		    vsHash += 51ULL;
 
-        // Vertex fetch
-        if (_activeFetchShader->mtlFetchVertexManually)
-            vsHash += 349ULL;
+            // Vertex fetch
+            if (_activeFetchShader->mtlFetchVertexManually)
+                vsHash += 349ULL;
 		}
 	}
+#endif
 
 	_shaderBaseHash_vs = vsHash;
 }

--- a/src/Cafe/HW/Latte/Renderer/Metal/LatteTextureMtl.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/LatteTextureMtl.cpp
@@ -2,9 +2,6 @@
 #include "Cafe/HW/Latte/Renderer/Metal/LatteTextureViewMtl.h"
 #include "Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h"
 #include "Cafe/HW/Latte/Renderer/Metal/LatteToMtl.h"
-#include "Common/precompiled.h"
-#include "Metal/MTLResource.hpp"
-#include "Metal/MTLTexture.hpp"
 
 LatteTextureMtl::LatteTextureMtl(class MetalRenderer* mtlRenderer, Latte::E_DIM dim, MPTR physAddress, MPTR physMipAddress, Latte::E_GX2SURFFMT format, uint32 width, uint32 height, uint32 depth, uint32 pitch, uint32 mipLevels, uint32 swizzle,
 	Latte::E_HWTILEMODE tileMode, bool isDepth)
@@ -12,7 +9,7 @@ LatteTextureMtl::LatteTextureMtl(class MetalRenderer* mtlRenderer, Latte::E_DIM 
 {
     MTL::TextureDescriptor* desc = MTL::TextureDescriptor::alloc()->init();
     desc->setStorageMode(MTL::StorageModePrivate);
-    desc->setCpuCacheMode(MTL::CPUCacheModeWriteCombined);
+    //desc->setCpuCacheMode(MTL::CPUCacheModeWriteCombined);
 
 	sint32 effectiveBaseWidth = width;
 	sint32 effectiveBaseHeight = height;

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalCommon.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalCommon.h
@@ -101,3 +101,11 @@ inline bool FormatIsRenderable(Latte::E_GX2SURFFMT format)
 {
     return !Latte::IsCompressedFormat(format);
 }
+
+template <typename... T>
+inline void executeCommand(fmt::format_string<T...> fmt, T&&... args) {
+    std::string command = fmt::format(fmt, std::forward<T>(args)...);
+    int res = system(command.c_str());
+    if (res != 0)
+        cemuLog_log(LogType::Force, "command \"{}\" failed with exit code {}", command, res);
+}

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalCommon.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalCommon.h
@@ -103,11 +103,16 @@ inline bool FormatIsRenderable(Latte::E_GX2SURFFMT format)
 }
 
 template <typename... T>
-inline void executeCommand(fmt::format_string<T...> fmt, T&&... args) {
+inline bool executeCommand(fmt::format_string<T...> fmt, T&&... args) {
     std::string command = fmt::format(fmt, std::forward<T>(args)...);
     int res = system(command.c_str());
     if (res != 0)
+    {
         cemuLog_log(LogType::Force, "command \"{}\" failed with exit code {}", command, res);
+        return false;
+    }
+
+    return true;
 }
 
 class MemoryMappedFile

--- a/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.cpp
@@ -29,7 +29,7 @@ public:
 		if (m_threadsActive.exchange(true))
 			return;
 		// create thread pool
-		const uint32 threadCount = 8;
+		const uint32 threadCount = 2;
 		for (uint32 i = 0; i < threadCount; ++i)
 			s_threads.emplace_back(&ShaderMtlThreadPool::CompilerThreadFunc, this);
 	}
@@ -295,8 +295,10 @@ void RendererShaderMtl::CompileInternal()
             mslFile.close();
 
             // Compile
-			executeCommand("xcrun -sdk macosx metal -o {}.ir -c {}.metal -w", baseFilename, baseFilename);
-			executeCommand("xcrun -sdk macosx metallib -o {}.metallib {}.ir", baseFilename, baseFilename);
+			if (!executeCommand("xcrun -sdk macosx metal -o {}.ir -c {}.metal -w", baseFilename, baseFilename))
+			    return;
+			if (!executeCommand("xcrun -sdk macosx metallib -o {}.metallib {}.ir", baseFilename, baseFilename))
+                return;
 
 			// Clean up
 			executeCommand("rm {}.metal", baseFilename);

--- a/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.cpp
@@ -11,7 +11,7 @@
 
 #define METAL_AIR_CACHE_NAME "Cemu_AIR_cache"
 #define METAL_AIR_CACHE_PATH "/Volumes/" METAL_AIR_CACHE_NAME
-#define METAL_AIR_CACHE_SIZE (512 * 1024 * 1024)
+#define METAL_AIR_CACHE_SIZE (16 * 1024 * 1024)
 #define METAL_AIR_CACHE_BLOCK_COUNT (METAL_AIR_CACHE_SIZE / 512)
 
 static bool s_isLoadingShadersMtl{false};
@@ -313,6 +313,9 @@ void RendererShaderMtl::CompileInternal()
 			uint64 h1, h2;
 			GenerateShaderPrecompiledCacheFilename(m_type, m_baseHash, m_auxHash, h1, h2);
 			s_airCache->AddFile({ h1, h2 }, airData.data(), airData.size());
+
+			// Clean up
+			executeCommand("rm {}.metallib", baseFilename);
 		}
     }
     else

--- a/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.h
@@ -69,5 +69,7 @@ private:
 
 	void CompileInternal();
 
+	void CompileFromAIR(std::span<uint8> data);
+
 	void FinishCompilation();
 };

--- a/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.h
@@ -73,5 +73,7 @@ private:
 
 	void CompileInternal();
 
+	void CompileToAIR();
+
 	void FinishCompilation();
 };

--- a/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/RendererShaderMtl.h
@@ -67,9 +67,11 @@ private:
 
 	bool ShouldCountCompilation() const;
 
-	void CompileInternal();
+	MTL::Library* LibraryFromSource();
 
-	void CompileFromAIR(std::span<uint8> data);
+	MTL::Library* LibraryFromAIR(std::span<uint8> data);
+
+	void CompileInternal();
 
 	void FinishCompilation();
 };

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -69,6 +69,7 @@ std::list<fs::path> _getCachesPaths(const TitleId& titleId)
 		ActiveSettings::GetCachePath(L"shaderCache/driver/vk/{:016x}.bin", titleId),
 		ActiveSettings::GetCachePath(L"shaderCache/precompiled/{:016x}_spirv.bin", titleId),
 		ActiveSettings::GetCachePath(L"shaderCache/precompiled/{:016x}_gl.bin", titleId),
+		ActiveSettings::GetCachePath(L"shaderCache/precompiled/{:016x}_air.bin", titleId),
 		ActiveSettings::GetCachePath(L"shaderCache/transferable/{:016x}_shaders.bin", titleId),
 		ActiveSettings::GetCachePath(L"shaderCache/transferable/{:016x}_mtlshaders.bin", titleId),
 		ActiveSettings::GetCachePath(L"shaderCache/transferable/{:016x}_vkpipeline.bin", titleId),


### PR DESCRIPTION
Caches Metal shaders in the AIR format to make subsequent loads almost instant. Unfortunately, the first load will take a very long time due to Apple's shader compiler library being a command line utility.